### PR TITLE
solanum: allow modifying connection classes

### DIFF
--- a/config/machines/hub.staging.hackint.org/default.nix
+++ b/config/machines/hub.staging.hackint.org/default.nix
@@ -1,6 +1,7 @@
 {
   imports = [
     ./hardware-configuration.nix
+    ../../roles/ircd.nix
     ../../roles/staging.nix
   ];
 

--- a/config/machines/leaf1.staging.hackint.org/default.nix
+++ b/config/machines/leaf1.staging.hackint.org/default.nix
@@ -1,6 +1,7 @@
 {
   imports = [
     ./hardware-configuration.nix
+    ../../roles/ircd.nix
     ../../roles/staging.nix
   ];
 

--- a/config/roles/all.nix
+++ b/config/roles/all.nix
@@ -2,16 +2,4 @@
   imports = [
     ../modules
   ];
-
-
-  hackint = {
-    solanum = {
-      enable = true;
-      exempts = [
-        # TODO: add monitoring
-      ];
-      opers = {
-      };
-    };
-  };
 }

--- a/config/roles/ircd.nix
+++ b/config/roles/ircd.nix
@@ -3,10 +3,20 @@
   hackint = {
     solanum = {
       enable = true;
+      isHub = lib.mkDefault false;
       exempts = [
         # TODO: add monitoring
       ];
       opers = {
+      };
+      classes = {
+        server = {
+          pingTime = "5 minutes";
+          autoconnFreq = "1 minute";
+          maxConnections = 16;
+          maxAutoconn = if config.hackint.solanum.isHub then 0 else 1;
+          sendQ = "2 megabytes";
+        };
       };
     };
   };

--- a/config/roles/ircd.nix
+++ b/config/roles/ircd.nix
@@ -1,0 +1,13 @@
+{ config, lib, ... }:
+{
+  hackint = {
+    solanum = {
+      enable = true;
+      exempts = [
+        # TODO: add monitoring
+      ];
+      opers = {
+      };
+    };
+  };
+}


### PR DESCRIPTION
As it would be prudent not to publish our exact connection limits, these
settings cannot be hardcoded in the template. Instead they need to be
set from within our secrets storage.