### PR TITLE
Create a common source for or nixpkgs expression

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -1,7 +1,5 @@
 let
-  sources = import ../nix/sources.nix {};
-
-  pkgs = import sources."nixos-21.05" {};
+  pkgs = import ../nix { release = "21.05"; };
   lib = pkgs.lib;
 
   mkMachine = hostname: {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,8 @@
+{ system ? builtins.currentSystem, config ? { }, release ? "nixpkgs-unstable" }:
+let
+  sources = import ./sources.nix { };
+  overlays = import ./overlays.nix sources;
+in
+import sources.${release} {
+  inherit overlays config;
+}

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -1,0 +1,6 @@
+sources:
+[
+  (self: super: {
+    morph = self.callPackage sources.morph { };
+  })
+]

--- a/shell.nix
+++ b/shell.nix
@@ -1,12 +1,10 @@
 let
-  sources = import ./nix/sources.nix {};
-
-  pkgs = import sources."nixpkgs-unstable" {};
+  pkgs = import ./nix {};
 
 in pkgs.mkShell {
   buildInputs = with pkgs; [
     git
-    (callPackage sources.morph {})
     niv
+    morph
   ];
 }


### PR DESCRIPTION
This commit provides a uniform way of accessing our nixpkgs instance
including all the applied overlays and custom packages that we require.