### PR TITLE
Add experimental NixOS VM tests

### DIFF
--- a/test.nix
+++ b/test.nix
@@ -1,0 +1,24 @@
+let
+  pkgs = import ./nix { };
+  inherit (pkgs) lib;
+  machines = builtins.removeAttrs (import ./config/default.nix) [ "network" ];
+  fakeDeploymetModule = {
+    options.deployment = lib.mkOption {
+      type = lib.types.attrs;
+    };
+  };
+
+  nixosTest = import (pkgs.path + "/nixos/lib/testing-python.nix") { inherit (pkgs) system; };
+in
+nixosTest.makeTest {
+  nodes = lib.mapAttrs
+    (name: machine: {
+      imports = [
+        machine
+        fakeDeploymetModule
+        { _module.args.name = name; }
+      ];
+    })
+    machines;
+  testScript = "";
+}


### PR DESCRIPTION
This allows us to run the morph declared machines within a NixOS VM test
environment.