### PR TITLE
Add module for DNS master

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -18,4 +18,5 @@ in
 
   staging_hub = mkMachine "hub.staging.hackint.org";
   staging_leaf1 = mkMachine "leaf1.staging.hackint.org";
+  staging_dns = mkMachine "dns.staging.hackint.org";
 }

--- a/config/machines/dns.staging.hackint.org/default.nix
+++ b/config/machines/dns.staging.hackint.org/default.nix
@@ -1,0 +1,13 @@
+{
+  imports = [
+    ./hardware-configuration.nix
+    ../../roles/staging.nix
+    ../../roles/dns.nix
+  ];
+
+  networking = {
+    hostName = "dns";
+  };
+
+  system.stateVersion = "21.05";
+}

--- a/config/machines/dns.staging.hackint.org/hardware-configuration.nix
+++ b/config/machines/dns.staging.hackint.org/hardware-configuration.nix
@@ -1,0 +1,9 @@
+{
+
+  boot.loader.systemd-boot.enable = true;
+
+  fileSystems."/" = {
+    device = "/dev/sda1";
+    fsType = "ext4";
+  };
+}

--- a/config/modules/acme/default.nix
+++ b/config/modules/acme/default.nix
@@ -1,19 +1,55 @@
-{ config, ... }:
-{
-  users.groups.acme = { };
+{ config, lib, pkgs, ... }:
 
-  security.acme = {
-    email = "mail@hackint.org";
-    acceptTerms = true;
-    certs = {
-      "${config.networking.fqdn}" = {
-        extraDomainNames = [
-          "hackint.org"
-          "irc.hackint.org"
-        ];
-        dnsProvider = "rfc2136";
-        credentialsFile = /etc/nixos/secrets/acme/environment;
-        group = "acme";
+with lib;
+
+{
+  options = with types; {
+    security.acme = {
+      nameserver = mkOption {
+        type = str;
+        description = ''
+          Nameserver to push RFC2136 updates to.
+        '';
+      };
+      tsig.key = mkOption {
+        type = str;
+        description = ''
+          Name of the secret key as defined in DNS server configuration.
+        '';
+      };
+      tsig.secret = mkOption {
+        type = str;
+        description = ''
+          Secret key payload.
+        '';
+      };
+    };
+  };
+
+  config = {
+    users.groups.acme = { };
+
+    security.acme = {
+      email = "mail@hackint.org";
+      acceptTerms = true;
+      certs = {
+        "${config.networking.fqdn}" = {
+          extraDomainNames = [
+            "hackint.org"
+            "irc.hackint.org"
+          ];
+          dnsProvider = "rfc2136";
+          credentialsFile = pkgs.writeText "acme-credentials" (with config.security.acme; ''
+            LEGO_EXPERIMENTAL_CNAME_SUPPORT=true
+            RFC2136_NAMESERVER=${nameserver}
+            RFC2136_TSIG_ALGORITHM=hmac-sha512.
+            RFC2136_TSIG_KEY=${tsig.key}
+            RFC2136_TSIG_SECRET=${tsig.secret}
+            RFC2136_PROPAGATION_TIMEOUT=3600
+            RFC2136_SEQUENCE_INTERVAL=60
+          '');
+          group = "acme";
+        };
       };
     };
   };

--- a/config/modules/default.nix
+++ b/config/modules/default.nix
@@ -4,5 +4,6 @@
     #./atheme
     ./network
     ./solanum
+    ./dns/master
   ];
 }

--- a/config/modules/dns/master/default.nix
+++ b/config/modules/dns/master/default.nix
@@ -1,0 +1,178 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.hackint.dns.master;
+
+  zone = pkgs.writeText "${cfg.zones.dynamic.domain}.zone" ''
+    $ORIGIN ${cfg.zones.dynamic.domain}.
+    $TTL 60
+
+    @ SOA ${head cfg.nameservers} mail.hackint.org 0 200 300 1209600 300
+
+    ${concatMapStringsSep "\n"
+      (server: "@ NS ${server}")
+      cfg.nameservers}
+  '';
+
+in
+{
+  options.hackint.dns.master = with types; {
+    enable = mkEnableOption "the DNS master";
+
+    secrets = mkOption {
+      type = attrsOf str;
+      description = ''
+        Secret TSIG keys.
+      '';
+      default = { };
+    };
+
+    upstreams = mkOption {
+      type = attrsOf (listOf str);
+      description = ''
+        Remote adrresses of upstream servers.
+      '';
+      default = { };
+    };
+
+    zones = mkOption {
+      type = attrsOf (submodule ({ name, ... }: {
+        options = {
+          domain = mkOption {
+            type = str;
+            description = ''
+              The full domain name of the zone.
+            '';
+            default = name;
+          };
+
+          file = mkOption {
+            type = path;
+            description = ''
+              The zone file.
+            '';
+          };
+
+          upstream = mkOption {
+            type = enum (attrNames cfg.upstreams);
+            description = ''
+              Upstream servers for this zone.
+            '';
+          };
+
+          nameservers = mkOption {
+            type = listOf str;
+            description = ''
+              FQDNs of public serving servers.
+              The first host is used as the primary nameserver.
+            '';
+          };
+
+          dynamic = mkOption {
+            type = nullOr (submodule {
+              options = {
+                networks = mkOption {
+                  type = listOf str;
+                  description = ''
+                    Hosts and networks allowed to perform dynamic updates.
+                  '';
+                };
+
+                secrets = mkOption {
+                  type = listOf (enum (attrNames cfg.secrets));
+                  description = ''
+                    Secret TSIG keys allowed for dynamic updates.
+                  '';
+                };
+              };
+            });
+            description = ''
+              Allow dynamic updates for this zone.
+            '';
+            default = null;
+          };
+        };
+      }));
+      description = ''
+        The zones to serve.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Let systemd-resolved not listen on 127.0.0.53:53 to avoid conflicts with
+    # kresd listening on wildcard.
+    services.resolved.extraConfig = ''
+      DNSStubListener=no
+    '';
+
+    services.knot = {
+      enable = true;
+
+      extraConfig =
+        let
+          concatList = concatMapStringsSep "," (e: ''"${e}"'');
+        in
+        ''
+          server:
+            listen: [ "0.0.0.0@53", "::@53" ]
+
+          key:
+          ${concatStringsSep "\n" (mapAttrsToList (name: secret: ''
+            - id: "${name}"
+              algorithm: hmac-sha512
+              secret: "${secret}"
+          '') cfg.secrets)}
+
+          remote:
+          ${concatStringsSep "\n" (mapAttrsToList (name: servers: ''
+            - id: "${name}"
+              address: [${concatMapStringsSep "," (s: "\"${s}@53\"") servers}]
+          '') cfg.upstreams)}
+
+          acl:
+          ${concatStringsSep "\n" (mapAttrsToList (name: zone: ''
+            - id: "upstream:${name}"
+              address: [${concatList cfg.upstreams."${zone.upstream}"}]
+              action: transfer
+          '') cfg.zones)}
+
+          ${concatStringsSep "\n" (mapAttrsToList (name: zone: ''
+            - id: "update:${name}"
+              address: [${concatList zone.dynamic.networks}]
+              action: update
+              update-type: TXT
+              key: [ ${concatList zone.dynamic.secrets} ]
+          '') (filterAttrs (_: zone: zone.dynamic != null) cfg.zones))}
+
+          policy:
+            - id: "default"
+              algorithm: ed25519
+              cds-cdnskey-publish: always
+
+          template:
+            - id: default
+              semantic-checks: true
+              zonefile-sync: -1
+              zonefile-load: difference-no-serial
+              serial-policy: dateserial
+              journal-content: all
+              dnssec-signing: on
+              dnssec-policy: default
+
+          zone:
+          ${concatStringsSep "\n" (mapAttrsToList (name: zone: ''
+            - domain: "${zone.domain}"
+              file: "${zone.file}"
+              notify: "${zone.upstream}"
+              acl: [ ${concatList (
+                (singleton "upstream:${name}") ++
+                (optional (zone.dynamic != null) "update:${name}")
+              )} ]
+          '') cfg.zones)}
+        '';
+    };
+  };
+}

--- a/config/roles/dns.nix
+++ b/config/roles/dns.nix
@@ -1,0 +1,50 @@
+{ config, nodes, lib, pkgs, ... }:
+
+with lib;
+
+let
+  dynamic = rec {
+    domain = "dyn.${config.networking.domain}";
+
+    nameservers = config.hackint.dns.master.zones."${domain}".nameservers;
+
+    file = pkgs.writeText "${domain}.zone" ''
+      $ORIGIN ${domain}.
+      $TTL 60
+
+      @ SOA ${head nameservers} mail.hackint.org 0 200 300 1209600 300
+
+      ${concatMapStringsSep "\n"
+        (server: "@ NS ${server}")
+        nameservers}
+    '';
+  };
+in
+{
+  hackint.dns.master = {
+    enable = true;
+
+    upstreams = {
+      "example" = [ "1.2.3.4" ];
+    };
+
+    secrets = mapAttrs'
+      (name: node: {
+        name = node.config.security.acme.tsig.key;
+        value = node.config.security.acme.tsig.secret;
+      })
+      nodes;
+
+    zones."${dynamic.domain}" = {
+      inherit (dynamic) domain file;
+
+      nameservers = [ "ns.example.com" "ns1.example.com" ];
+      upstream = "example";
+
+      dynamic.networks = [ "0.0.0.0/0" ];
+      dynamic.secrets = mapAttrsToList
+        (_: node: node.config.security.acme.tsig.key)
+        nodes;
+    };
+  };
+}

--- a/config/roles/staging.nix
+++ b/config/roles/staging.nix
@@ -1,7 +1,13 @@
+{ name, nodes, lib, ... }:
+
 {
   networking = {
     domain = "staging.hackint.org";
   };
 
   deployment.tags = [ "staging" ];
+
+  security.acme.nameserver = lib.head nodes.staging_dns.config.hackint.network.addresses;
+  security.acme.tsig.key = "acme:${name}";
+  security.acme.tsig.secret = "";
 }


### PR DESCRIPTION
The added module configures knot to serve a dynamic zone and several static
zones as a (hidden) master.

Fixes #9.