### PR TITLE
network: match wan by mac, rename and configure interface

### DIFF
--- a/config/machines/hub.staging.hackint.org/default.nix
+++ b/config/machines/hub.staging.hackint.org/default.nix
@@ -9,6 +9,18 @@
     hostName = "hub";
   };
 
+  hackint.network = {
+    macAddress = "00:00:00:11:11:11";
+    addresses = [
+      "192.0.2.2/24"
+      "2001:DB8::1/64"
+    ];
+    gateways = [
+      "192.0.2.1"
+      "fe80::1"
+    ];
+  };
+
   hackint.solanum.sid = "100";
 
   system.stateVersion = "21.05";

--- a/config/machines/leaf1.staging.hackint.org/default.nix
+++ b/config/machines/leaf1.staging.hackint.org/default.nix
@@ -9,6 +9,18 @@
     hostName = "leaf1";
   };
 
+  hackint.network = {
+    macAddress = "00:00:00:11:11:12";
+    addresses = [
+      "192.0.2.3/24"
+      "2001:DB8::2/64"
+    ];
+    gateways = [
+      "192.0.2.1"
+      "fe80::1"
+    ];
+  };
+
   hackint.solanum.sid = "200";
 
   system.stateVersion = "21.05";


### PR DESCRIPTION
Identify the WAN-facing interface by MAC Address, so we can use it to
rename it to a common name, that we can rely on throughout further
configuration.

Further configures addresses and default gateways, and configures a
routable state of the WAN interface as the requirement for the
network-online.target.